### PR TITLE
Assign setbfree reverb mix to cc 99

### DIFF
--- a/setbfree/cfg/zynthian.cfg
+++ b/setbfree/cfg/zynthian.cfg
@@ -7,4 +7,5 @@
 
 #Customized MIDI Controller
 midi.controller.upper.23=overdrive.enable
+midi.controller.upper.65=rotary.speed-select
 midi.controller.upper.99=reverb.mix

--- a/setbfree/cfg/zynthian.cfg
+++ b/setbfree/cfg/zynthian.cfg
@@ -7,3 +7,4 @@
 
 #Customized MIDI Controller
 midi.controller.upper.23=overdrive.enable
+midi.controller.upper.99=reverb.mix


### PR DESCRIPTION
The reverb mix is not mapped to any controller by default, so assign
it to controller 99 so that a control can be added in the ui.

Controller 95 is the next unassigned controller in setbfree, but 99
was chosen here in case the setbfree source chooses 95 as their next
used number.