### PR TITLE
Obxd: Allow continuous values for filter keyboard follow (#902)

### DIFF
--- a/lv2-custom/Obxd.lv2/Obxd.ttl
+++ b/lv2-custom/Obxd.lv2/Obxd.ttl
@@ -699,15 +699,6 @@
         lv2:default 0.000000 ;
         lv2:minimum 0.0 ;
         lv2:maximum 1.0 ;
-        lv2:scalePoint [
-            rdf:value 0.0 ;
-            rdfs:label "OFF" ;
-            rdfs:comment "OFF" ;
-        ], [
-            rdf:value 1.0 ;
-            rdfs:label "ON" ;
-            rdfs:comment "ON" ;
-        ];
         pg:group obxd_lv2:G501_FLTR ;
     ] ,
     [


### PR DESCRIPTION
The underlying DSP code in OB-Xd allows for setting the filter keyboard follow parameter (index 47) to float values, so let us take advantage of this and remove the limitation that the parameter can only be set to 0 or 1, and allow the complete range of values between these two extremes.