### PR TITLE
novachord.ttl: Fix max value for Attack parameter

### DIFF
--- a/lv2-custom/novachord.lv2/novachord.ttl
+++ b/lv2-custom/novachord.lv2/novachord.ttl
@@ -349,7 +349,7 @@ plug:G105_PEDALS
 
 		lv2:default 0.0 ;
 		lv2:minimum 0.0 ;
-		lv2:maximum 7.0 ;
+		lv2:maximum 6.0 ;
 		lv2:scalePoint [
 			rdfs:label "1" ;
 			rdf:value 0 ;
@@ -371,9 +371,6 @@ plug:G105_PEDALS
 		], [
 			rdfs:label "7" ;
 			rdf:value 6.0 ;
-		], [
-			rdfs:label "8" ;
-			rdf:value 7.0 ;
 		] ;
 		lv2:displayPriority 699 ;
 		pg:group plug:G104_MODULATION ;


### PR DESCRIPTION
The Attack parameter has a max value of 7, not 8, so change the parameter definition accordingly.