### PR TITLE
lv2-custom/RipplerX.lv2: Update dsp.ttl to v1.5.18

### DIFF
--- a/lv2-custom/RipplerX.lv2/dsp.ttl
+++ b/lv2-custom/RipplerX.lv2/dsp.ttl
@@ -76,7 +76,7 @@ plug:a_model
 	rdfs:range atom:Float ;
 	lv2:default 0 ;
 	lv2:minimum 0 ;
-	lv2:maximum 8	 ;
+	lv2:maximum 11	 ;
 	lv2:portProperty lv2:enumeration ;
 	lv2:scalePoint [
 		rdfs:label "String" ;
@@ -105,6 +105,15 @@ plug:a_model
 	], [
 		rdfs:label "Closed Tube" ;
 		rdf:value 8 ;
+	], [
+		rdfs:label "Marimba2" ;
+		rdf:value 9 ;
+	], [
+		rdfs:label "Bell" ;
+		rdf:value 10 ;
+	], [
+		rdfs:label "Djembe" ;
+		rdf:value 11 ;
 	] .
 
 plug:a_partials
@@ -115,7 +124,7 @@ plug:a_partials
 	rdfs:range atom:Float ;
 	lv2:default 3 ;
 	lv2:minimum 0 ;
-	lv2:maximum 4	 ;
+	lv2:maximum 6	 ;
 	lv2:portProperty lv2:enumeration ;
 	lv2:scalePoint [
 		rdfs:label "4" ;
@@ -132,6 +141,12 @@ plug:a_partials
 	], [
 		rdfs:label "64" ;
 		rdf:value 4 ;
+	], [
+		rdfs:label "1" ;
+		rdf:value 5 ;
+	], [
+		rdfs:label "2" ;
+		rdf:value 6 ;
 	] .
 
 plug:a_decay
@@ -181,7 +196,7 @@ plug:a_rel
 	rdfs:label "A Release" ;
 	rdfs:range atom:Float ;
 	lv2:default 1 ;
-	lv2:minimum 0 ;
+	lv2:minimum 0.001 ;
 	lv2:maximum 1 .
 
 plug:a_inharm
@@ -210,9 +225,9 @@ plug:a_cut
 	lv2:displayPriority 88 ;
 	rdfs:label "A LowCut" ;
 	rdfs:range atom:Float ;
-	lv2:default 20 ;
-	lv2:minimum 20 ;
-	lv2:maximum 20000 .
+	lv2:default -2.23517e-08 ;
+	lv2:minimum -1 ;
+	lv2:maximum 1 .
 
 plug:a_radius
 	a lv2:Parameter ;
@@ -270,7 +285,7 @@ plug:b_model
 	rdfs:range atom:Float ;
 	lv2:default 0 ;
 	lv2:minimum 0 ;
-	lv2:maximum 8	 ;
+	lv2:maximum 11	 ;
 	lv2:portProperty lv2:enumeration ;
 	lv2:scalePoint [
 		rdfs:label "String" ;
@@ -299,6 +314,15 @@ plug:b_model
 	], [
 		rdfs:label "Closed Tube" ;
 		rdf:value 8 ;
+	], [
+		rdfs:label "Marimba2" ;
+		rdf:value 9 ;
+	], [
+		rdfs:label "Bell" ;
+		rdf:value 10 ;
+	], [
+		rdfs:label "Djembe" ;
+		rdf:value 11 ;
 	] .
 
 plug:b_partials
@@ -309,7 +333,7 @@ plug:b_partials
 	rdfs:range atom:Float ;
 	lv2:default 3 ;
 	lv2:minimum 0 ;
-	lv2:maximum 4	 ;
+	lv2:maximum 6	 ;
 	lv2:portProperty lv2:enumeration ;
 	lv2:scalePoint [
 		rdfs:label "4" ;
@@ -326,6 +350,12 @@ plug:b_partials
 	], [
 		rdfs:label "64" ;
 		rdf:value 4 ;
+	], [
+		rdfs:label "1" ;
+		rdf:value 5 ;
+	], [
+		rdfs:label "2" ;
+		rdf:value 6 ;
 	] .
 
 plug:b_decay
@@ -375,7 +405,7 @@ plug:b_rel
 	rdfs:label "B Release" ;
 	rdfs:range atom:Float ;
 	lv2:default 1 ;
-	lv2:minimum 0 ;
+	lv2:minimum 0.001 ;
 	lv2:maximum 1 .
 
 plug:b_inharm
@@ -404,9 +434,9 @@ plug:b_cut
 	lv2:displayPriority 68;
 	rdfs:label "B LowCut" ;
 	rdfs:range atom:Float ;
-	lv2:default 20 ;
-	lv2:minimum 20 ;
-	lv2:maximum 20000 .
+	lv2:default -2.23517e-08 ;
+	lv2:minimum -1 ;
+	lv2:maximum 1 .
 
 plug:b_radius
 	a lv2:Parameter ;
@@ -508,7 +538,7 @@ plug:noise_att
 	rdfs:range atom:Float ;
 	lv2:default 1 ;
 	lv2:minimum 1 ;
-	lv2:maximum 5000 .
+	lv2:maximum 20000 .
 
 plug:noise_dec
 	a lv2:Parameter ;
@@ -519,7 +549,7 @@ plug:noise_dec
 	rdfs:range atom:Float ;
 	lv2:default 500 ;
 	lv2:minimum 1 ;
-	lv2:maximum 5000 .
+	lv2:maximum 20000 .
 
 plug:noise_sus
 	a lv2:Parameter ;
@@ -549,8 +579,8 @@ plug:vel_mallet_mix
 	lv2:displayPriority 53 ;
 	rdfs:label "Vel Mallet Mix" ;
 	rdfs:range atom:Float ;
-	lv2:default 0 ;
-	lv2:minimum 0 ;
+	lv2:default -2.23517e-08 ;
+	lv2:minimum -1 ;
 	lv2:maximum 1 .
 
 plug:vel_mallet_res
@@ -559,8 +589,8 @@ plug:vel_mallet_res
 	lv2:displayPriority 55 ;
 	rdfs:label "Vel Mallet Resonance" ;
 	rdfs:range atom:Float ;
-	lv2:default 0 ;
-	lv2:minimum 0 ;
+	lv2:default -2.23517e-08 ;
+	lv2:minimum -1 ;
 	lv2:maximum 1 .
 
 plug:vel_mallet_stiff
@@ -569,8 +599,8 @@ plug:vel_mallet_stiff
 	lv2:displayPriority 54 ;
 	rdfs:label "Vel Mallet Stiffness" ;
 	rdfs:range atom:Float ;
-	lv2:default 0 ;
-	lv2:minimum 0 ;
+	lv2:default -2.23517e-08 ;
+	lv2:minimum -1 ;
 	lv2:maximum 1 .
 
 plug:vel_noise_mix
@@ -579,8 +609,8 @@ plug:vel_noise_mix
 	lv2:displayPriority 42 ;
 	rdfs:label "Vel Noise Mix" ;
 	rdfs:range atom:Float ;
-	lv2:default 0 ;
-	lv2:minimum 0 ;
+	lv2:default -2.23517e-08 ;
+	lv2:minimum -1 ;
 	lv2:maximum 1 .
 
 plug:vel_noise_res
@@ -589,8 +619,8 @@ plug:vel_noise_res
 	lv2:displayPriority 43 ;
 	rdfs:label "Vel Noise Resonance" ;
 	rdfs:range atom:Float ;
-	lv2:default 0 ;
-	lv2:minimum 0 ;
+	lv2:default -2.23517e-08 ;
+	lv2:minimum -1 ;
 	lv2:maximum 1 .
 
 plug:vel_a_decay
@@ -599,8 +629,8 @@ plug:vel_a_decay
 	lv2:displayPriority 83;
 	rdfs:label "Vel A Decay" ;
 	rdfs:range atom:Float ;
-	lv2:default 0 ;
-	lv2:minimum 0 ;
+	lv2:default -2.23517e-08 ;
+	lv2:minimum -1 ;
 	lv2:maximum 1 .
 
 plug:vel_a_hit
@@ -609,8 +639,8 @@ plug:vel_a_hit
 	lv2:displayPriority 82;
 	rdfs:label "Vel A Hit" ;
 	rdfs:range atom:Float ;
-	lv2:default 0 ;
-	lv2:minimum 0 ;
+	lv2:default -2.23517e-08 ;
+	lv2:minimum -1 ;
 	lv2:maximum 1 .
 
 plug:vel_a_inharm
@@ -619,8 +649,8 @@ plug:vel_a_inharm
 	lv2:displayPriority 81;
 	rdfs:label "Vel A Inharmonic" ;
 	rdfs:range atom:Float ;
-	lv2:default 0 ;
-	lv2:minimum 0 ;
+	lv2:default -2.23517e-08 ;
+	lv2:minimum -1 ;
 	lv2:maximum 1 .
 
 plug:vel_b_decay
@@ -629,8 +659,8 @@ plug:vel_b_decay
 	lv2:displayPriority 63;
 	rdfs:label "Vel B Decay" ;
 	rdfs:range atom:Float ;
-	lv2:default 0 ;
-	lv2:minimum 0 ;
+	lv2:default -2.23517e-08 ;
+	lv2:minimum -1 ;
 	lv2:maximum 1 .
 
 plug:vel_b_hit
@@ -639,8 +669,8 @@ plug:vel_b_hit
 	lv2:displayPriority 62;
 	rdfs:label "Vel B Hit" ;
 	rdfs:range atom:Float ;
-	lv2:default 0 ;
-	lv2:minimum 0 ;
+	lv2:default -2.23517e-08 ;
+	lv2:minimum -1 ;
 	lv2:maximum 1 .
 
 plug:vel_b_inharm
@@ -649,8 +679,8 @@ plug:vel_b_inharm
 	lv2:displayPriority 61;
 	rdfs:label "Vel B Inharmonic" ;
 	rdfs:range atom:Float ;
-	lv2:default 0 ;
-	lv2:minimum 0 ;
+	lv2:default -2.23517e-08 ;
+	lv2:minimum -1 ;
 	lv2:maximum 1 .
 
 plug:couple
@@ -701,6 +731,11 @@ plug:gain
 	lv2:minimum -24 ;
 	lv2:maximum 24 .
 
+plug:input_group_1
+	a pg:InputGroup ;
+	lv2:name "Sidechain" ;
+	lv2:symbol "input_group_1" .
+
 plug:output_group_1
 	a pg:OutputGroup ;
 	lv2:name "Output" ;
@@ -711,8 +746,8 @@ plug:output_group_1
 	a lv2:InstrumentPlugin ;
 	doap:name "RipplerX" ;
 	doap:description "RipplerX" ;
-	lv2:minorVersion 3 ;
-	lv2:microVersion 4 ;
+	lv2:minorVersion 5 ;
+	lv2:microVersion 18 ;
 	doap:maintainer [
 		a foaf:Person ;
 		foaf:name "Tilr" ;
@@ -721,7 +756,7 @@ plug:output_group_1
 	] ;
 	doap:release [
 		a doap:Version ;
-		doap:revision "1.3.4" ;
+		doap:revision "1.5.18" ;
 	] ;
 	lv2:optionalFeature
 		lv2:hardRTCapable ;
@@ -731,6 +766,7 @@ plug:output_group_1
 		urid:map ,
 		opts:options ,
 		bufs:boundedBlockLength ;
+	pg:mainInput plug:input_group_1 ;
 	pg:mainOutput plug:output_group_1 ;
 	patch:writable
 		plug:mallet_mix ,
@@ -845,39 +881,53 @@ plug:output_group_1
 		plug:ab_split ,
 		plug:gain ;
 	lv2:port [
-		a lv2:OutputPort , lv2:AudioPort ;
+		a lv2:InputPort , lv2:AudioPort ;
 		lv2:index 0 ;
+		lv2:symbol "audio_in_1" ;
+		lv2:name "Audio In 1" ;
+		pg:group plug:input_group_1 ;
+		lv2:designation <http://lv2plug.in/ns/ext/port-groups#left> ;
+	] , [
+		a lv2:InputPort , lv2:AudioPort ;
+		lv2:index 1 ;
+		lv2:symbol "audio_in_2" ;
+		lv2:name "Audio In 2" ;
+		pg:group plug:input_group_1 ;
+		lv2:designation <http://lv2plug.in/ns/ext/port-groups#right> ;
+	] , [
+		a lv2:OutputPort , lv2:AudioPort ;
+		lv2:index 2 ;
 		lv2:symbol "audio_out_1" ;
 		lv2:name "Audio Out 1" ;
 		pg:group plug:output_group_1 ;
 		lv2:designation <http://lv2plug.in/ns/ext/port-groups#left> ;
 	] , [
 		a lv2:OutputPort , lv2:AudioPort ;
-		lv2:index 1 ;
+		lv2:index 3 ;
 		lv2:symbol "audio_out_2" ;
 		lv2:name "Audio Out 2" ;
 		pg:group plug:output_group_1 ;
 		lv2:designation <http://lv2plug.in/ns/ext/port-groups#right> ;
 	] , [
 		a lv2:InputPort , atom:AtomPort ;
-		rsz:minimumSize 12152 ;
+		rsz:minimumSize 13736 ;
 		atom:bufferType atom:Sequence ;
 		atom:supports
 			midi:MidiEvent ,
 			patch:Message ,
 			time:Position ;
 		lv2:designation lv2:control ;
-		lv2:index 2 ;
+		lv2:index 4 ;
 		lv2:symbol "in" ;
 		lv2:name "In" ;
 	] , [
 		a lv2:OutputPort , atom:AtomPort ;
-		rsz:minimumSize 12152 ;
+		rsz:minimumSize 13736 ;
 		atom:bufferType atom:Sequence ;
 		atom:supports
 			patch:Message ;
 		lv2:designation lv2:control ;
-		lv2:index 3 ;
+		lv2:index 5 ;
 		lv2:symbol "out" ;
 		lv2:name "Out" ;
 	] , [
@@ -885,7 +935,7 @@ plug:output_group_1
 		lv2:designation lv2:latency ;
 		lv2:symbol "latency" ;
 		lv2:name "Latency" ;
-		lv2:index 4 ;
+		lv2:index 6 ;
 		lv2:portProperty lv2:reportsLatency , lv2:integer , lv2:connectionOptional , pprop:notOnGUI ;
 		units:unit units:frame ;
 	] , [
@@ -896,7 +946,7 @@ plug:output_group_1
 		lv2:default 0.0 ;
 		lv2:minimum 0.0 ;
 		lv2:maximum 1.0 ;
-		lv2:index 5 ;
+		lv2:index 7 ;
 		lv2:portProperty lv2:toggled , lv2:connectionOptional , pprop:notOnGUI ;
 	] , [
 		a lv2:InputPort , lv2:ControlPort ;
@@ -906,7 +956,7 @@ plug:output_group_1
 		lv2:default 1.0 ;
 		lv2:minimum 0.0 ;
 		lv2:maximum 1.0 ;
-		lv2:index 6 ;
+		lv2:index 8 ;
 		lv2:portProperty lv2:toggled , lv2:connectionOptional , pprop:notOnGUI ;
 	] ;
 	opts:supportedOption

--- a/lv2-custom/RipplerX.lv2/dsp.ttl
+++ b/lv2-custom/RipplerX.lv2/dsp.ttl
@@ -20,10 +20,90 @@
 @prefix urid:  <http://lv2plug.in/ns/ext/urid#> .
 @prefix xsd:   <http://www.w3.org/2001/XMLSchema#> .
 
+plug:mallet_type
+	a lv2:Parameter ;
+	pg:group plug:G4B_MALLET_MAT ;
+	lv2:displayPriority 244 ;
+	rdfs:label "Mallet Type" ;
+	rdfs:range atom:Float ;
+	lv2:default 0 ;
+	lv2:minimum 0 ;
+	lv2:maximum 25	 ;
+	lv2:portProperty lv2:enumeration ;
+	lv2:scalePoint [
+		rdfs:label "Impulse" ;
+		rdf:value 0 ;
+	], [
+		rdfs:label "User File" ;
+		rdf:value 11 ;
+	], [
+		rdfs:label "Click 1" ;
+		rdf:value 12 ;
+	], [
+		rdfs:label "Click 2" ;
+		rdf:value 13 ;
+	], [
+		rdfs:label "Click 3" ;
+		rdf:value 14 ;
+	], [
+		rdfs:label "Click 4" ;
+		rdf:value 15 ;
+	], [
+		rdfs:label "Click 5" ;
+		rdf:value 16 ;
+	], [
+		rdfs:label "Click 6" ;
+		rdf:value 17 ;
+	], [
+		rdfs:label "Blip" ;
+		rdf:value 18 ;
+	], [
+		rdfs:label "Blop" ;
+		rdf:value 19 ;
+	], [
+		rdfs:label "Metal 1" ;
+		rdf:value 20 ;
+	], [
+		rdfs:label "Metal 2" ;
+		rdf:value 21 ;
+	], [
+		rdfs:label "Wood" ;
+		rdf:value 22 ;
+	], [
+		rdfs:label "Strike" ;
+		rdf:value 23 ;
+	], [
+		rdfs:label "Perc 1" ;
+		rdf:value 24 ;
+	], [
+		rdfs:label "Perc 2" ;
+		rdf:value 25 ;
+	] .
+
+plug:mallet_pitch
+	a lv2:Parameter ;
+	pg:group plug:G4A_MALLET_SETUP ;
+	lv2:displayPriority 252 ;
+	rdfs:label "Mallet Pitch" ;
+	rdfs:range atom:Float ;
+	lv2:default -5.36442e-07 ;
+	lv2:minimum -24 ;
+	lv2:maximum 24 .
+
+plug:mallet_filter
+	a lv2:Parameter ;
+	pg:group plug:G4C_MALLET_TONE ;
+	lv2:displayPriority 232 ;
+	rdfs:label "Mallet Filter" ;
+	rdfs:range atom:Float ;
+	lv2:default -2.23517e-08 ;
+	lv2:minimum -1 ;
+	lv2:maximum 1 .
+
 plug:mallet_mix
 	a lv2:Parameter ;
-	pg:group plug:G5_GLOBAL_MIX ;
-	lv2:displayPriority 38 ;
+	pg:group plug:G4A_MALLET_SETUP ;
+	lv2:displayPriority 254 ;
 	rdfs:label "Mallet Mix" ;
 	rdfs:range atom:Float ;
 	lv2:default 0 ;
@@ -32,8 +112,8 @@ plug:mallet_mix
 
 plug:mallet_res
 	a lv2:Parameter ;
-	pg:group plug:G3A_MALLET_SETUP ;
-	lv2:displayPriority 59 ;
+	pg:group plug:G4C_MALLET_TONE ;
+	lv2:displayPriority 234 ;
 	rdfs:label "Mallet Resonance" ;
 	rdfs:range atom:Float ;
 	lv2:default 0.8 ;
@@ -42,18 +122,28 @@ plug:mallet_res
 
 plug:mallet_stiff
 	a lv2:Parameter ;
-	pg:group plug:G3A_MALLET_SETUP ;
-	lv2:displayPriority 58 ;
-	rdfs:label "Mallet Stifness" ;
+	pg:group plug:G4B_MALLET_MAT ;
+	lv2:displayPriority 243 ;
+	rdfs:label "Mallet Stiffness" ;
 	rdfs:range atom:Float ;
 	lv2:default 600 ;
 	lv2:minimum 100 ;
 	lv2:maximum 5000 .
 
+plug:mallet_ktrack
+	a lv2:Parameter ;
+	pg:group plug:G4A_MALLET_SETUP ;
+	lv2:displayPriority 251 ;
+	rdfs:label "Mallet Keytrack" ;
+	rdfs:range atom:Float ;
+	lv2:default 0 ;
+	lv2:minimum 0 ;
+	lv2:maximum 1 .
+
 plug:a_on
 	a lv2:Parameter ;
-	pg:group plug:G1A_RES_A_SETUP ;
-	lv2:displayPriority 99 ;
+	pg:group plug:G1A_RES_SETUP ;
+	lv2:displayPriority 404 ;
 	rdfs:label "A ON" ;
 	rdfs:range atom:Float ;
 	lv2:default 1 ;
@@ -70,8 +160,8 @@ plug:a_on
 
 plug:a_model
 	a lv2:Parameter ;
-	pg:group plug:G1A_RES_A_SETUP ;
-	lv2:displayPriority 98 ;
+	pg:group plug:G2A_RES_A_MODEL ;
+	lv2:displayPriority 354 ;
 	rdfs:label "A Model" ;
 	rdfs:range atom:Float ;
 	lv2:default 0 ;
@@ -118,8 +208,8 @@ plug:a_model
 
 plug:a_partials
 	a lv2:Parameter ;
-	pg:group plug:G1B_RES_A_MAT ;
-	lv2:displayPriority 95 ;
+	pg:group plug:G2A_RES_A_MODEL ;
+	lv2:displayPriority 353 ;
 	rdfs:label "A Partials" ;
 	rdfs:range atom:Float ;
 	lv2:default 3 ;
@@ -151,8 +241,8 @@ plug:a_partials
 
 plug:a_decay
 	a lv2:Parameter ;
-	pg:group plug:G1D_RES_A_TIME ;
-	lv2:displayPriority 86 ;
+	pg:group plug:G2D_RES_A_ATTEN ;
+	lv2:displayPriority 324 ;
 	rdfs:label "A Decay" ;
 	rdfs:range atom:Float ;
 	lv2:default 1 ;
@@ -161,8 +251,8 @@ plug:a_decay
 
 plug:a_damp
 	a lv2:Parameter ;
-	pg:group plug:G1B_RES_A_MAT ;
-	lv2:displayPriority 94 ;
+	pg:group plug:G2B_RES_A_MAT ;
+	lv2:displayPriority 344 ;
 	rdfs:label "A Material" ;
 	rdfs:range atom:Float ;
 	lv2:default -2.23517e-08 ;
@@ -171,8 +261,8 @@ plug:a_damp
 
 plug:a_tone
 	a lv2:Parameter ;
-	pg:group plug:G1C_RES_A_TONE ;
-	lv2:displayPriority 91 ;
+	pg:group plug:G2C_RES_A_TONE ;
+	lv2:displayPriority 334 ;
 	rdfs:label "A Tone" ;
 	rdfs:range atom:Float ;
 	lv2:default -2.23517e-08 ;
@@ -181,8 +271,8 @@ plug:a_tone
 
 plug:a_hit
 	a lv2:Parameter ;
-	pg:group plug:G1B_RES_A_MAT ;
-	lv2:displayPriority 93 ;
+	pg:group plug:G2B_RES_A_MAT ;
+	lv2:displayPriority 342 ;
 	rdfs:label "A HitPos" ;
 	rdfs:range atom:Float ;
 	lv2:default 0.26 ;
@@ -191,8 +281,8 @@ plug:a_hit
 
 plug:a_rel
 	a lv2:Parameter ;
-	pg:group plug:G1D_RES_A_TIME ;
-	lv2:displayPriority 86 ;
+	pg:group plug:G2D_RES_A_ATTEN ;
+	lv2:displayPriority 322 ;
 	rdfs:label "A Release" ;
 	rdfs:range atom:Float ;
 	lv2:default 1 ;
@@ -201,8 +291,8 @@ plug:a_rel
 
 plug:a_inharm
 	a lv2:Parameter ;
-	pg:group plug:G1C_RES_A_TONE ;
-	lv2:displayPriority 90 ;
+	pg:group plug:G2C_RES_A_TONE ;
+	lv2:displayPriority 332 ;
 	rdfs:label "A Inharmonic" ;
 	rdfs:range atom:Float ;
 	lv2:default 0.0001 ;
@@ -211,8 +301,8 @@ plug:a_inharm
 
 plug:a_ratio
 	a lv2:Parameter ;
-	pg:group plug:G1C_RES_A_TONE ;
-	lv2:displayPriority 89 ;
+	pg:group plug:G2A_RES_A_MODEL ;
+	lv2:displayPriority 352 ;
 	rdfs:label "A Ratio" ;
 	rdfs:range atom:Float ;
 	lv2:default 1 ;
@@ -221,8 +311,8 @@ plug:a_ratio
 
 plug:a_cut
 	a lv2:Parameter ;
-	pg:group plug:G1C_RES_A_TONE ;
-	lv2:displayPriority 88 ;
+	pg:group plug:G2D_RES_A_ATTEN ;
+	lv2:displayPriority 321 ;
 	rdfs:label "A LowCut" ;
 	rdfs:range atom:Float ;
 	lv2:default -2.23517e-08 ;
@@ -231,8 +321,8 @@ plug:a_cut
 
 plug:a_radius
 	a lv2:Parameter ;
-	pg:group plug:G1B_RES_A_MAT ;
-	lv2:displayPriority 92 ;
+	pg:group plug:G2A_RES_A_MODEL ;
+	lv2:displayPriority 351 ;
 	rdfs:label "A Tube Radius" ;
 	rdfs:range atom:Float ;
 	lv2:default 0.5 ;
@@ -241,8 +331,8 @@ plug:a_radius
 
 plug:a_coarse
 	a lv2:Parameter ;
-	pg:group plug:G1A_RES_A_SETUP ;
-	lv2:displayPriority 97;
+	pg:group plug:G1C_RES_PITCH ;
+	lv2:displayPriority 384 ;
 	rdfs:label "A coarse pitch" ;
 	rdfs:range atom:Float ;
 	lv2:default 0 ;
@@ -251,8 +341,8 @@ plug:a_coarse
 
 plug:a_fine
 	a lv2:Parameter ;
-	pg:group plug:G1A_RES_A_SETUP ;
-	lv2:displayPriority 96;
+	pg:group plug:G1C_RES_PITCH ;
+	lv2:displayPriority 383 ;
 	rdfs:label "A fine pitch" ;
 	rdfs:range atom:Float ;
 	lv2:default 0 ;
@@ -261,8 +351,8 @@ plug:a_fine
 
 plug:b_on
 	a lv2:Parameter ;
-	pg:group plug:G2A_RES_B_SETUP ;
-	lv2:displayPriority 79;
+	pg:group plug:G1A_RES_SETUP ;
+	lv2:displayPriority 403 ;
 	rdfs:label "B ON" ;
 	rdfs:range atom:Float ;
 	lv2:default 0 ;
@@ -279,8 +369,8 @@ plug:b_on
 
 plug:b_model
 	a lv2:Parameter ;
-	pg:group plug:G2A_RES_B_SETUP ;
-	lv2:displayPriority 78;
+	pg:group plug:G3A_RES_B_MODEL ;
+	lv2:displayPriority 304 ;
 	rdfs:label "B Model" ;
 	rdfs:range atom:Float ;
 	lv2:default 0 ;
@@ -327,8 +417,8 @@ plug:b_model
 
 plug:b_partials
 	a lv2:Parameter ;
-	pg:group plug:G2B_RES_B_MAT ;
-	lv2:displayPriority 75;
+	pg:group plug:G3A_RES_B_MODEL ;
+	lv2:displayPriority 303 ;
 	rdfs:label "B Partials" ;
 	rdfs:range atom:Float ;
 	lv2:default 3 ;
@@ -360,8 +450,8 @@ plug:b_partials
 
 plug:b_decay
 	a lv2:Parameter ;
-	pg:group plug:G2D_RES_B_TIME ;
-	lv2:displayPriority 67;
+	pg:group plug:G3D_RES_B_ATTEN ;
+	lv2:displayPriority 274 ;
 	rdfs:label "B Decay" ;
 	rdfs:range atom:Float ;
 	lv2:default 1 ;
@@ -370,8 +460,8 @@ plug:b_decay
 
 plug:b_damp
 	a lv2:Parameter ;
-	pg:group plug:G2B_RES_B_MAT ;
-	lv2:displayPriority 74;
+	pg:group plug:G3B_RES_B_MAT ;
+	lv2:displayPriority 294 ;
 	rdfs:label "B Material" ;
 	rdfs:range atom:Float ;
 	lv2:default -2.23517e-08 ;
@@ -380,8 +470,8 @@ plug:b_damp
 
 plug:b_tone
 	a lv2:Parameter ;
-	pg:group plug:G2C_RES_B_TONE ;
-	lv2:displayPriority 71;
+	pg:group plug:G3C_RES_B_TONE ;
+	lv2:displayPriority 284 ;
 	rdfs:label "B Tone" ;
 	rdfs:range atom:Float ;
 	lv2:default -2.23517e-08 ;
@@ -390,8 +480,8 @@ plug:b_tone
 
 plug:b_hit
 	a lv2:Parameter ;
-	pg:group plug:G2B_RES_B_MAT ;
-	lv2:displayPriority 73;
+	pg:group plug:G3B_RES_B_MAT ;
+	lv2:displayPriority 292 ;
 	rdfs:label "B HitPos" ;
 	rdfs:range atom:Float ;
 	lv2:default 0.26 ;
@@ -400,8 +490,8 @@ plug:b_hit
 
 plug:b_rel
 	a lv2:Parameter ;
-	pg:group plug:G2D_RES_B_TIME ;
-	lv2:displayPriority 66;
+	pg:group plug:G3D_RES_B_ATTEN ;
+	lv2:displayPriority 272 ;
 	rdfs:label "B Release" ;
 	rdfs:range atom:Float ;
 	lv2:default 1 ;
@@ -410,8 +500,8 @@ plug:b_rel
 
 plug:b_inharm
 	a lv2:Parameter ;
-	pg:group plug:G2C_RES_B_TONE ;
-	lv2:displayPriority 70;
+	pg:group plug:G3C_RES_B_TONE ;
+	lv2:displayPriority 282 ;
 	rdfs:label "B Inharmonic" ;
 	rdfs:range atom:Float ;
 	lv2:default 0.0001 ;
@@ -420,8 +510,8 @@ plug:b_inharm
 
 plug:b_ratio
 	a lv2:Parameter ;
-	pg:group plug:G2C_RES_B_TONE ;
-	lv2:displayPriority 69;
+	pg:group plug:G3A_RES_B_MODEL ;
+	lv2:displayPriority 302 ;
 	rdfs:label "B Ratio" ;
 	rdfs:range atom:Float ;
 	lv2:default 1 ;
@@ -430,8 +520,8 @@ plug:b_ratio
 
 plug:b_cut
 	a lv2:Parameter ;
-	pg:group plug:G2C_RES_B_TONE ;
-	lv2:displayPriority 68;
+	pg:group plug:G3D_RES_B_ATTEN ;
+	lv2:displayPriority 271 ;
 	rdfs:label "B LowCut" ;
 	rdfs:range atom:Float ;
 	lv2:default -2.23517e-08 ;
@@ -440,8 +530,8 @@ plug:b_cut
 
 plug:b_radius
 	a lv2:Parameter ;
-	pg:group plug:G2B_RES_B_MAT ;
-	lv2:displayPriority 72;
+	pg:group plug:G3A_RES_B_MODEL ;
+	lv2:displayPriority 301 ;
 	rdfs:label "B Tube Radius" ;
 	rdfs:range atom:Float ;
 	lv2:default 0.5 ;
@@ -450,8 +540,8 @@ plug:b_radius
 
 plug:b_coarse
 	a lv2:Parameter ;
-	pg:group plug:G2A_RES_B_SETUP ;
-	lv2:displayPriority 77;
+	pg:group plug:G1C_RES_PITCH ;
+	lv2:displayPriority 382 ;
 	rdfs:label "B coarse pitch" ;
 	rdfs:range atom:Float ;
 	lv2:default 0 ;
@@ -460,18 +550,28 @@ plug:b_coarse
 
 plug:b_fine
 	a lv2:Parameter ;
-	pg:group plug:G2A_RES_B_SETUP ;
-	lv2:displayPriority 76;
+	pg:group plug:G1C_RES_PITCH ;
+	lv2:displayPriority 381 ;
 	rdfs:label "B fine pitch" ;
 	rdfs:range atom:Float ;
 	lv2:default 0 ;
 	lv2:minimum -99 ;
 	lv2:maximum 99 .
 
+plug:noise_osc
+	a lv2:Parameter ;
+	pg:group plug:G5A_NOISE_SETUP ;
+	lv2:displayPriority 202 ;
+	rdfs:label "Noise DC" ;
+	rdfs:range atom:Float ;
+	lv2:default 0 ;
+	lv2:minimum 0 ;
+	lv2:maximum 1 .
+
 plug:noise_mix
 	a lv2:Parameter ;
-	pg:group plug:G5_GLOBAL_MIX ;
-	lv2:displayPriority 37 ;
+	pg:group plug:G5A_NOISE_SETUP ;
+	lv2:displayPriority 204 ;
 	rdfs:label "Noise Mix" ;
 	rdfs:range atom:Float ;
 	lv2:default 0 ;
@@ -480,8 +580,8 @@ plug:noise_mix
 
 plug:noise_res
 	a lv2:Parameter ;
-	pg:group plug:G4A_NOISE_FILT ;
-	lv2:displayPriority 49 ;
+	pg:group plug:G5B_NOISE_FILT ;
+	lv2:displayPriority 194 ;
 	rdfs:label "Noise Resonance" ;
 	rdfs:range atom:Float ;
 	lv2:default 0 ;
@@ -490,8 +590,8 @@ plug:noise_res
 
 plug:noise_filter_mode
 	a lv2:Parameter ;
-	pg:group plug:G4A_NOISE_FILT ;
-	lv2:displayPriority 51 ;
+	pg:group plug:G5B_NOISE_FILT ;
+	lv2:displayPriority 191 ;
 	rdfs:label "Noise Filter Mode" ;
 	rdfs:range atom:Float ;
 	lv2:default 2 ;
@@ -511,8 +611,8 @@ plug:noise_filter_mode
 
 plug:noise_filter_freq
 	a lv2:Parameter ;
-	pg:group plug:G4A_NOISE_FILT ;
-	lv2:displayPriority 50 ;
+	pg:group plug:G5B_NOISE_FILT ;
+	lv2:displayPriority 193 ;
 	rdfs:label "Noise Filter Freq" ;
 	rdfs:range atom:Float ;
 	lv2:default 20 ;
@@ -521,8 +621,8 @@ plug:noise_filter_freq
 
 plug:noise_filter_q
 	a lv2:Parameter ;
-	pg:group plug:G4A_NOISE_FILT ;
-	lv2:displayPriority 48 ;
+	pg:group plug:G5B_NOISE_FILT ;
+	lv2:displayPriority 192 ;
 	rdfs:label "Noise Filter Q" ;
 	rdfs:range atom:Float ;
 	lv2:default 0.707 ;
@@ -531,8 +631,8 @@ plug:noise_filter_q
 
 plug:noise_att
 	a lv2:Parameter ;
-	pg:group plug:G4B_NOISE_ENV ;
-	lv2:displayPriority 47 ;
+	pg:group plug:G5D_NOISE_ENV ;
+	lv2:displayPriority 174 ;
 	lv2:designation param:attack ;
 	rdfs:label "Noise Attack" ;
 	rdfs:range atom:Float ;
@@ -542,9 +642,9 @@ plug:noise_att
 
 plug:noise_dec
 	a lv2:Parameter ;
-	pg:group plug:G4B_NOISE_ENV ;
+	pg:group plug:G5D_NOISE_ENV ;
+	lv2:displayPriority 173 ;
 	lv2:designation param:decay ;
-	lv2:displayPriority 46 ;
 	rdfs:label "Noise Decay" ;
 	rdfs:range atom:Float ;
 	lv2:default 500 ;
@@ -553,8 +653,8 @@ plug:noise_dec
 
 plug:noise_sus
 	a lv2:Parameter ;
-	pg:group plug:G4B_NOISE_ENV ;
-	lv2:displayPriority 45 ;
+	pg:group plug:G5D_NOISE_ENV ;
+	lv2:displayPriority 172 ;
 	lv2:designation param:sustain ;
 	rdfs:label "Noise Sustain" ;
 	rdfs:range atom:Float ;
@@ -564,19 +664,49 @@ plug:noise_sus
 
 plug:noise_rel
 	a lv2:Parameter ;
-	pg:group plug:G4B_NOISE_ENV ;
-	lv2:displayPriority 44 ;
+	pg:group plug:G5D_NOISE_ENV ;
+	lv2:displayPriority 171 ;
 	lv2:designation param:release ;
 	rdfs:label "Noise Release" ;
 	rdfs:range atom:Float ;
 	lv2:default 500 ;
 	lv2:minimum 1 ;
-	lv2:maximum 5000 .
+	lv2:maximum 20000 .
+
+plug:noise_att_ten
+	a lv2:Parameter ;
+	pg:group plug:G5F_NOISE_ENV_TENSION ;
+	lv2:displayPriority 154 ;
+	rdfs:label "Noise Attack Tension" ;
+	rdfs:range atom:Float ;
+	lv2:default 0.4 ;
+	lv2:minimum -1 ;
+	lv2:maximum 1 .
+
+plug:noise_dec_ten
+	a lv2:Parameter ;
+	pg:group plug:G5F_NOISE_ENV_TENSION ;
+	lv2:displayPriority 153 ;
+	rdfs:label "Noise Decay Tension" ;
+	rdfs:range atom:Float ;
+	lv2:default 0.4 ;
+	lv2:minimum -1 ;
+	lv2:maximum 1 .
+
+plug:noise_rel_ten
+	a lv2:Parameter ;
+	pg:group plug:G5F_NOISE_ENV_TENSION ;
+	lv2:displayPriority 152 ;
+	rdfs:label "Noise Release Tension" ;
+	rdfs:range atom:Float ;
+	lv2:default 0.4 ;
+	lv2:minimum -1 ;
+	lv2:maximum 1 .
 
 plug:vel_mallet_mix
 	a lv2:Parameter ;
-	pg:group plug:G3B_MALLET_VELMOD ;
-	lv2:displayPriority 53 ;
+	pg:group plug:G4A_MALLET_SETUP ;
+	lv2:displayPriority 253 ;
 	rdfs:label "Vel Mallet Mix" ;
 	rdfs:range atom:Float ;
 	lv2:default -2.23517e-08 ;
@@ -585,8 +715,8 @@ plug:vel_mallet_mix
 
 plug:vel_mallet_res
 	a lv2:Parameter ;
-	pg:group plug:G3B_MALLET_VELMOD ;
-	lv2:displayPriority 55 ;
+	pg:group plug:G4C_MALLET_TONE ;
+	lv2:displayPriority 233 ;
 	rdfs:label "Vel Mallet Resonance" ;
 	rdfs:range atom:Float ;
 	lv2:default -2.23517e-08 ;
@@ -595,8 +725,8 @@ plug:vel_mallet_res
 
 plug:vel_mallet_stiff
 	a lv2:Parameter ;
-	pg:group plug:G3B_MALLET_VELMOD ;
-	lv2:displayPriority 54 ;
+	pg:group plug:G4B_MALLET_MAT ;
+	lv2:displayPriority 242 ;
 	rdfs:label "Vel Mallet Stiffness" ;
 	rdfs:range atom:Float ;
 	lv2:default -2.23517e-08 ;
@@ -605,8 +735,8 @@ plug:vel_mallet_stiff
 
 plug:vel_noise_mix
 	a lv2:Parameter ;
-	pg:group plug:G4C_NOISE_VELMOD ;
-	lv2:displayPriority 42 ;
+	pg:group plug:G5A_NOISE_SETUP ;
+	lv2:displayPriority 203 ;
 	rdfs:label "Vel Noise Mix" ;
 	rdfs:range atom:Float ;
 	lv2:default -2.23517e-08 ;
@@ -615,9 +745,69 @@ plug:vel_noise_mix
 
 plug:vel_noise_res
 	a lv2:Parameter ;
-	pg:group plug:G4C_NOISE_VELMOD ;
-	lv2:displayPriority 43 ;
+	pg:group plug:G5C_NOISE_FILT_VELMOD ;
+	lv2:displayPriority 184 ;
 	rdfs:label "Vel Noise Resonance" ;
+	rdfs:range atom:Float ;
+	lv2:default -2.23517e-08 ;
+	lv2:minimum -1 ;
+	lv2:maximum 1 .
+
+plug:vel_noise_freq
+	a lv2:Parameter ;
+	pg:group plug:G5C_NOISE_FILT_VELMOD ;
+	lv2:displayPriority 183 ;
+	rdfs:label "Vel Noise Frequency" ;
+	rdfs:range atom:Float ;
+	lv2:default -2.23517e-08 ;
+	lv2:minimum -1 ;
+	lv2:maximum 1 .
+
+plug:vel_noise_att
+	a lv2:Parameter ;
+	pg:group plug:G5E_NOISE_ENV_VELMOD ;
+	lv2:displayPriority 164 ;
+	rdfs:label "Vel Noise Attack" ;
+	rdfs:range atom:Float ;
+	lv2:default -2.23517e-08 ;
+	lv2:minimum -1 ;
+	lv2:maximum 1 .
+
+plug:vel_noise_dec
+	a lv2:Parameter ;
+	pg:group plug:G5E_NOISE_ENV_VELMOD ;
+	lv2:displayPriority 163 ;
+	rdfs:label "Vel Noise Decay" ;
+	rdfs:range atom:Float ;
+	lv2:default -2.23517e-08 ;
+	lv2:minimum -1 ;
+	lv2:maximum 1 .
+
+plug:vel_noise_sus
+	a lv2:Parameter ;
+	pg:group plug:G5E_NOISE_ENV_VELMOD ;
+	lv2:displayPriority 162 ;
+	rdfs:label "Vel Noise Sustain" ;
+	rdfs:range atom:Float ;
+	lv2:default -2.23517e-08 ;
+	lv2:minimum -1 ;
+	lv2:maximum 1 .
+
+plug:vel_noise_rel
+	a lv2:Parameter ;
+	pg:group plug:G5E_NOISE_ENV_VELMOD ;
+	lv2:displayPriority 161 ;
+	rdfs:label "Vel Noise Release" ;
+	rdfs:range atom:Float ;
+	lv2:default -2.23517e-08 ;
+	lv2:minimum -1 ;
+	lv2:maximum 1 .
+
+plug:vel_noise_q
+	a lv2:Parameter ;
+	pg:group plug:G5C_NOISE_FILT_VELMOD ;
+	lv2:displayPriority 182 ;
+	rdfs:label "Vel Noise Q" ;
 	rdfs:range atom:Float ;
 	lv2:default -2.23517e-08 ;
 	lv2:minimum -1 ;
@@ -625,8 +815,8 @@ plug:vel_noise_res
 
 plug:vel_a_decay
 	a lv2:Parameter ;
-	pg:group plug:G1E_RES_A_VELMOD ;
-	lv2:displayPriority 83;
+	pg:group plug:G2D_RES_A_ATTEN ;
+	lv2:displayPriority 323 ;
 	rdfs:label "Vel A Decay" ;
 	rdfs:range atom:Float ;
 	lv2:default -2.23517e-08 ;
@@ -635,8 +825,8 @@ plug:vel_a_decay
 
 plug:vel_a_hit
 	a lv2:Parameter ;
-	pg:group plug:G1E_RES_A_VELMOD ;
-	lv2:displayPriority 82;
+	pg:group plug:G2B_RES_A_MAT ;
+	lv2:displayPriority 341 ;
 	rdfs:label "Vel A Hit" ;
 	rdfs:range atom:Float ;
 	lv2:default -2.23517e-08 ;
@@ -645,9 +835,29 @@ plug:vel_a_hit
 
 plug:vel_a_inharm
 	a lv2:Parameter ;
-	pg:group plug:G1E_RES_A_VELMOD ;
-	lv2:displayPriority 81;
+	pg:group plug:G2C_RES_A_TONE ;
+	lv2:displayPriority 331 ;
 	rdfs:label "Vel A Inharmonic" ;
+	rdfs:range atom:Float ;
+	lv2:default -2.23517e-08 ;
+	lv2:minimum -1 ;
+	lv2:maximum 1 .
+
+plug:vel_a_damp
+	a lv2:Parameter ;
+	pg:group plug:G2B_RES_A_MAT ;
+	lv2:displayPriority 343 ;
+	rdfs:label "Vel A Material" ;
+	rdfs:range atom:Float ;
+	lv2:default -2.23517e-08 ;
+	lv2:minimum -1 ;
+	lv2:maximum 1 .
+
+plug:vel_a_tone
+	a lv2:Parameter ;
+	pg:group plug:G2C_RES_A_TONE ;
+	lv2:displayPriority 333 ;
+	rdfs:label "Vel A Tone" ;
 	rdfs:range atom:Float ;
 	lv2:default -2.23517e-08 ;
 	lv2:minimum -1 ;
@@ -655,8 +865,8 @@ plug:vel_a_inharm
 
 plug:vel_b_decay
 	a lv2:Parameter ;
-	pg:group plug:G2E_RES_B_VELMOD ;
-	lv2:displayPriority 63;
+	pg:group plug:G3D_RES_B_ATTEN ;
+	lv2:displayPriority 273 ;
 	rdfs:label "Vel B Decay" ;
 	rdfs:range atom:Float ;
 	lv2:default -2.23517e-08 ;
@@ -665,8 +875,8 @@ plug:vel_b_decay
 
 plug:vel_b_hit
 	a lv2:Parameter ;
-	pg:group plug:G2E_RES_B_VELMOD ;
-	lv2:displayPriority 62;
+	pg:group plug:G3B_RES_B_MAT ;
+	lv2:displayPriority 291 ;
 	rdfs:label "Vel B Hit" ;
 	rdfs:range atom:Float ;
 	lv2:default -2.23517e-08 ;
@@ -675,9 +885,29 @@ plug:vel_b_hit
 
 plug:vel_b_inharm
 	a lv2:Parameter ;
-	pg:group plug:G2E_RES_B_VELMOD ;
-	lv2:displayPriority 61;
+	pg:group plug:G3C_RES_B_TONE ;
+	lv2:displayPriority 281 ;
 	rdfs:label "Vel B Inharmonic" ;
+	rdfs:range atom:Float ;
+	lv2:default -2.23517e-08 ;
+	lv2:minimum -1 ;
+	lv2:maximum 1 .
+
+plug:vel_b_damp
+	a lv2:Parameter ;
+	pg:group plug:G3B_RES_B_MAT ;
+	lv2:displayPriority 293 ;
+	rdfs:label "Vel B Material" ;
+	rdfs:range atom:Float ;
+	lv2:default -2.23517e-08 ;
+	lv2:minimum -1 ;
+	lv2:maximum 1 .
+
+plug:vel_b_tone
+	a lv2:Parameter ;
+	pg:group plug:G3C_RES_B_TONE ;
+	lv2:displayPriority 283 ;
+	rdfs:label "Vel B Tone" ;
 	rdfs:range atom:Float ;
 	lv2:default -2.23517e-08 ;
 	lv2:minimum -1 ;
@@ -685,8 +915,8 @@ plug:vel_b_inharm
 
 plug:couple
 	a lv2:Parameter ;
-	pg:group plug:G6_RES_MIX ;
-	lv2:displayPriority 35;
+	pg:group plug:G1B_RES_MIX ;
+	lv2:displayPriority 394 ;
 	rdfs:label "Coupling" ;
 	rdfs:range atom:Float ;
 	lv2:default 0 ;
@@ -703,8 +933,8 @@ plug:couple
 
 plug:ab_mix
 	a lv2:Parameter ;
-	pg:group plug:G6_RES_MIX ;
-	lv2:displayPriority 34;
+	pg:group plug:G1B_RES_MIX ;
+	lv2:displayPriority 393 ;
 	rdfs:label "A+B Mix" ;
 	rdfs:range atom:Float ;
 	lv2:default 0.5 ;
@@ -713,8 +943,8 @@ plug:ab_mix
 
 plug:ab_split
 	a lv2:Parameter ;
-	pg:group plug:G6_RES_MIX ;
-	lv2:displayPriority 33;
+	pg:group plug:G1B_RES_MIX ;
+	lv2:displayPriority 392 ;
 	rdfs:label "A>B Split" ;
 	rdfs:range atom:Float ;
 	lv2:default 0.01 ;
@@ -723,13 +953,77 @@ plug:ab_split
 
 plug:gain
 	a lv2:Parameter ;
-	pg:group plug:G5_GLOBAL_MIX ;
-	lv2:displayPriority 39 ;
+	pg:group plug:G1B_RES_MIX ;
+	lv2:displayPriority 391 ;
 	rdfs:label "Res Gain" ;
 	rdfs:range atom:Float ;
 	lv2:default -5.36442e-07 ;
 	lv2:minimum -24 ;
 	lv2:maximum 24 .
+
+plug:bend_range
+	a lv2:Parameter ;
+	pg:group plug:G6_KEY ;
+	lv2:displayPriority 104 ;
+	rdfs:label "PitchBend Range" ;
+	rdfs:range atom:Float ;
+	lv2:default 2 ;
+	lv2:minimum 1 ;
+	lv2:maximum 24 .
+
+plug:stereoizer
+	a lv2:Parameter ;
+	pg:group plug:G1A_RES_SETUP ;
+	lv2:displayPriority 402 ;
+	rdfs:label "Stereoizer" ;
+	rdfs:range atom:Float ;
+	lv2:default 1 ;
+	lv2:minimum 0 ;
+	lv2:maximum 1	 ;
+	lv2:portProperty lv2:enumeration , lv2:toggled ;
+	lv2:scalePoint [
+		rdfs:label "Off" ;
+		rdf:value 0 ;
+	], [
+		rdfs:label "On" ;
+		rdf:value 1 ;
+	] .
+
+plug:reuse_voices
+	a lv2:Parameter ;
+	pg:group plug:G6_KEY ;
+	lv2:displayPriority 103 ;
+	rdfs:label "Reuse Voices" ;
+	rdfs:range atom:Float ;
+	lv2:default 0 ;
+	lv2:minimum 0 ;
+	lv2:maximum 1	 ;
+	lv2:portProperty lv2:enumeration , lv2:toggled ;
+	lv2:scalePoint [
+		rdfs:label "Off" ;
+		rdf:value 0 ;
+	], [
+		rdfs:label "On" ;
+		rdf:value 1 ;
+	] .
+
+plug:fadeout_repeats
+	a lv2:Parameter ;
+	pg:group plug:G6_KEY ;
+	lv2:displayPriority 102 ;
+	rdfs:label "Fadeout Repeated Notes" ;
+	rdfs:range atom:Float ;
+	lv2:default 0 ;
+	lv2:minimum 0 ;
+	lv2:maximum 1	 ;
+	lv2:portProperty lv2:enumeration , lv2:toggled ;
+	lv2:scalePoint [
+		rdfs:label "Off" ;
+		rdf:value 0 ;
+	], [
+		rdfs:label "On" ;
+		rdf:value 1 ;
+	] .
 
 plug:input_group_1
 	a pg:InputGroup ;
@@ -769,9 +1063,13 @@ plug:output_group_1
 	pg:mainInput plug:input_group_1 ;
 	pg:mainOutput plug:output_group_1 ;
 	patch:writable
+		plug:mallet_type ,
+		plug:mallet_pitch ,
+		plug:mallet_filter ,
 		plug:mallet_mix ,
 		plug:mallet_res ,
 		plug:mallet_stiff ,
+		plug:mallet_ktrack ,
 		plug:a_on ,
 		plug:a_model ,
 		plug:a_partials ,
@@ -800,6 +1098,7 @@ plug:output_group_1
 		plug:b_radius ,
 		plug:b_coarse ,
 		plug:b_fine ,
+		plug:noise_osc ,
 		plug:noise_mix ,
 		plug:noise_res ,
 		plug:noise_filter_mode ,
@@ -809,25 +1108,46 @@ plug:output_group_1
 		plug:noise_dec ,
 		plug:noise_sus ,
 		plug:noise_rel ,
+		plug:noise_att_ten ,
+		plug:noise_dec_ten ,
+		plug:noise_rel_ten ,
 		plug:vel_mallet_mix ,
 		plug:vel_mallet_res ,
 		plug:vel_mallet_stiff ,
 		plug:vel_noise_mix ,
 		plug:vel_noise_res ,
+		plug:vel_noise_freq ,
+		plug:vel_noise_att ,
+		plug:vel_noise_dec ,
+		plug:vel_noise_sus ,
+		plug:vel_noise_rel ,
+		plug:vel_noise_q ,
 		plug:vel_a_decay ,
 		plug:vel_a_hit ,
 		plug:vel_a_inharm ,
+		plug:vel_a_damp ,
+		plug:vel_a_tone ,
 		plug:vel_b_decay ,
 		plug:vel_b_hit ,
 		plug:vel_b_inharm ,
+		plug:vel_b_damp ,
+		plug:vel_b_tone ,
 		plug:couple ,
 		plug:ab_mix ,
 		plug:ab_split ,
-		plug:gain ;
+		plug:gain ,
+		plug:bend_range ,
+		plug:stereoizer ,
+		plug:reuse_voices ,
+		plug:fadeout_repeats ;
 	patch:readable
+		plug:mallet_type ,
+		plug:mallet_pitch ,
+		plug:mallet_filter ,
 		plug:mallet_mix ,
 		plug:mallet_res ,
 		plug:mallet_stiff ,
+		plug:mallet_ktrack ,
 		plug:a_on ,
 		plug:a_model ,
 		plug:a_partials ,
@@ -856,6 +1176,7 @@ plug:output_group_1
 		plug:b_radius ,
 		plug:b_coarse ,
 		plug:b_fine ,
+		plug:noise_osc ,
 		plug:noise_mix ,
 		plug:noise_res ,
 		plug:noise_filter_mode ,
@@ -865,21 +1186,38 @@ plug:output_group_1
 		plug:noise_dec ,
 		plug:noise_sus ,
 		plug:noise_rel ,
+		plug:noise_att_ten ,
+		plug:noise_dec_ten ,
+		plug:noise_rel_ten ,
 		plug:vel_mallet_mix ,
 		plug:vel_mallet_res ,
 		plug:vel_mallet_stiff ,
 		plug:vel_noise_mix ,
 		plug:vel_noise_res ,
+		plug:vel_noise_freq ,
+		plug:vel_noise_att ,
+		plug:vel_noise_dec ,
+		plug:vel_noise_sus ,
+		plug:vel_noise_rel ,
+		plug:vel_noise_q ,
 		plug:vel_a_decay ,
 		plug:vel_a_hit ,
 		plug:vel_a_inharm ,
+		plug:vel_a_damp ,
+		plug:vel_a_tone ,
 		plug:vel_b_decay ,
 		plug:vel_b_hit ,
 		plug:vel_b_inharm ,
+		plug:vel_b_damp ,
+		plug:vel_b_tone ,
 		plug:couple ,
 		plug:ab_mix ,
 		plug:ab_split ,
-		plug:gain ;
+		plug:gain ,
+		plug:bend_range ,
+		plug:stereoizer ,
+		plug:reuse_voices ,
+		plug:fadeout_repeats ;
 	lv2:port [
 		a lv2:InputPort , lv2:AudioPort ;
 		lv2:index 0 ;
@@ -963,104 +1301,128 @@ plug:output_group_1
 		bufs:maxBlockLength .
 
 
-plug:G1A_RES_A_SETUP
-    a pg:InputGroup ;
-    lv2:name "Resonator A - Setup" ;
-    lv2:symbol "g1a_res_a_setup" ;
-    lv2:displayPriority 20 .
+plug:G1A_RES_SETUP
+	a pg:InputGroup ;
+	lv2:name "Resonator Setup" ;
+	lv2:symbol "g1a_res_setup" ;
+	lv2:displayPriority 40 .
 
-plug:G1B_RES_A_MAT
-    a pg:InputGroup ;
-    lv2:name "Resonator A - Material" ;
-    lv2:symbol "g1b_res_a_mat" ;
-    lv2:displayPriority 19 .
+plug:G1B_RES_MIX
+	a pg:InputGroup ;
+	lv2:name "Resonator Mix" ;
+	lv2:symbol "g1b_res_mix" ;
+	lv2:displayPriority 39 .
 
-plug:G1C_RES_A_TONE
-    a pg:InputGroup ;
-    lv2:name "Resonator A - Tone" ;
-    lv2:symbol "g1c_res_a_tone" ;
-    lv2:displayPriority 18 .
+plug:G1C_RES_PITCH
+	a pg:InputGroup ;
+	lv2:name "Resonator Pitch" ;
+	lv2:symbol "g1c_res_pitch" ;
+	lv2:displayPriority 38 .
 
-plug:G1D_RES_A_TIME
-    a pg:InputGroup ;
-    lv2:name "Resonator A - Time" ;
-    lv2:symbol "g1d_res_a_time" ;
-    lv2:displayPriority 17 .
+plug:G2A_RES_A_MODEL
+	a pg:InputGroup ;
+	lv2:name "Resonator A - Model" ;
+	lv2:symbol "g2a_res_a_model" ;
+	lv2:displayPriority 35 .
 
-plug:G1E_RES_A_VELMOD
-    a pg:InputGroup ;
-    lv2:name "Resonator A - Velocity Modulation" ;
-    lv2:symbol "g1e_res_a_velmod" ;
-    lv2:displayPriority 16 .
+plug:G2B_RES_A_MAT
+	a pg:InputGroup ;
+	lv2:name "Resonator A - Material" ;
+	lv2:symbol "g2b_res_a_mat" ;
+	lv2:displayPriority 34 .
 
-plug:G2A_RES_B_SETUP
-    a pg:InputGroup ;
-    lv2:name "Resonator B - Setup" ;
-    lv2:symbol "g2a_res_b_setup" ;
-    lv2:displayPriority 15 .
+plug:G2C_RES_A_TONE
+	a pg:InputGroup ;
+	lv2:name "Resonator A - Tone" ;
+	lv2:symbol "g2c_res_a_tone" ;
+	lv2:displayPriority 33 .
 
-plug:G2B_RES_B_MAT
-    a pg:InputGroup ;
-    lv2:name "Resonator B - Material" ;
-    lv2:symbol "g2b_res_b_mat" ;
-    lv2:displayPriority 14 .
+plug:G2D_RES_A_ATTEN
+	a pg:InputGroup ;
+	lv2:name "Resonator A - Attenuation" ;
+	lv2:symbol "g2d_res_a_atten" ;
+	lv2:displayPriority 32 .
 
-plug:G2C_RES_B_TONE
-    a pg:InputGroup ;
-    lv2:name "Resonator B - Tone" ;
-    lv2:symbol "g2c_res_b_tone" ;
-    lv2:displayPriority 13 .
+plug:G3A_RES_B_MODEL
+	a pg:InputGroup ;
+	lv2:name "Resonator B - Model" ;
+	lv2:symbol "g3a_res_b_model" ;
+	lv2:displayPriority 30 .
 
-plug:G2D_RES_B_TIME
-    a pg:InputGroup ;
-    lv2:name "Resonator B - Time" ;
-    lv2:symbol "g2d_res_b_time" ;
-    lv2:displayPriority 12 .
+plug:G3B_RES_B_MAT
+	a pg:InputGroup ;
+	lv2:name "Resonator B - Material" ;
+	lv2:symbol "g3b_res_b_mat" ;
+	lv2:displayPriority 29 .
 
-plug:G2E_RES_B_VELMOD
-    a pg:InputGroup ;
-    lv2:name "Resonator B - Velocity Modulation" ;
-    lv2:symbol "g2e_res_b_velmod" ;
-    lv2:displayPriority 11 .
+plug:G3C_RES_B_TONE
+	a pg:InputGroup ;
+	lv2:name "Resonator B - Tone" ;
+	lv2:symbol "g3c_res_b_tone" ;
+	lv2:displayPriority 28 .
 
-plug:G3A_MALLET_SETUP
-    a pg:InputGroup ;
-    lv2:name "Mallet - Setup" ;
-    lv2:symbol "g3_mallet_setup" ;
-    lv2:displayPriority 8 .
+plug:G3D_RES_B_ATTEN
+	a pg:InputGroup ;
+	lv2:name "Resonator B - Attenuation" ;
+	lv2:symbol "g3d_res_b_atten" ;
+	lv2:displayPriority 27 .
 
-plug:G3B_MALLET_VELMOD
-    a pg:InputGroup ;
-    lv2:name "Mallet - Velocity Modulation" ;
-    lv2:symbol "g3b_mallet_velmod" ;
-    lv2:displayPriority 7 .
+plug:G4A_MALLET_SETUP
+	a pg:InputGroup ;
+	lv2:name "Mallet Setup" ;
+	lv2:symbol "g4a_mallet_setup" ;
+	lv2:displayPriority 25 .
 
-plug:G4A_NOISE_FILT
-    a pg:InputGroup ;
-    lv2:name "Noise - Filter" ;
-    lv2:symbol "g4a_noise_filt" ;
-    lv2:displayPriority 6 .
+plug:G4B_MALLET_MAT
+	a pg:InputGroup ;
+	lv2:name "Mallet Material" ;
+	lv2:symbol "g4b_mallet_mat" ;
+	lv2:displayPriority 24 .
 
-plug:G4B_NOISE_ENV
-    a pg:InputGroup ;
-    lv2:name "Noise - Envelope" ;
-    lv2:symbol "g4b_noise_env" ;
-    lv2:displayPriority 5 .
+plug:G4C_MALLET_TONE
+	a pg:InputGroup ;
+	lv2:name "Mallet Tone" ;
+	lv2:symbol "g4c_mallet_tone" ;
+	lv2:displayPriority 23 .
 
-plug:G4C_NOISE_VELMOD
-    a pg:InputGroup ;
-    lv2:name "Noise - Velocity Modulation" ;
-    lv2:symbol "g4c_noise_velmod" ;
-    lv2:displayPriority 4 .
+plug:G5A_NOISE_SETUP
+	a pg:InputGroup ;
+	lv2:name "Noise Setup" ;
+	lv2:symbol "g5a_noise_setup" ;
+	lv2:displayPriority 20 .
 
-plug:G5_GLOBAL_MIX
-    a pg:InputGroup ;
-    lv2:name "Global Mix" ;
-    lv2:symbol "g5_global_mix" ;
-    lv2:displayPriority 3 .
+plug:G5B_NOISE_FILT
+	a pg:InputGroup ;
+	lv2:name "Noise Filter" ;
+	lv2:symbol "g5b_noise_filt" ;
+	lv2:displayPriority 19 .
 
-plug:G6_RES_MIX
-    a pg:InputGroup ;
-    lv2:name "Resonator Mix" ;
-    lv2:symbol "g6_res_mix" ;
-    lv2:displayPriority 10 .
+plug:G5C_NOISE_FILT_VELMOD
+	a pg:InputGroup ;
+	lv2:name "Noise Filter - Velocity Modulation" ;
+	lv2:symbol "g5c_noise_filt_velmod" ;
+	lv2:displayPriority 18 .
+
+plug:G5D_NOISE_ENV
+	a pg:InputGroup ;
+	lv2:name "Noise Envelope" ;
+	lv2:symbol "g5d_noise_env" ;
+	lv2:displayPriority 17 .
+
+plug:G5E_NOISE_ENV_VELMOD
+	a pg:InputGroup ;
+	lv2:name "Noise Envelope - Velocity Modulation" ;
+	lv2:symbol "g5e_noise_env_velmod" ;
+	lv2:displayPriority 16 .
+
+plug:G5F_NOISE_ENV_TENSION
+	a pg:InputGroup ;
+	lv2:name "Noise Envelope - Tension" ;
+	lv2:symbol "g5F_noise_env_ten" ;
+	lv2:displayPriority 15 .
+
+plug:G6_KEY
+	a pg:InputGroup ;
+	lv2:name "Keyboard" ;
+	lv2:symbol "g6_key" ;
+	lv2:displayPriority 10 .


### PR DESCRIPTION
RipplerX has had a few nice updates since it was originally added in https://github.com/zynthian/zynthian-sys/commit/c8d47201b4954706f3ef3cb98d3f4bceebf21589 plus custom dsp.ttl file in https://github.com/zynthian/zynthian-data/pull/20. See [past forum discussion here](https://discourse.zynthian.org/t/physical-modeling-engine-ripplerx-lv2-installation-pull-request-merged/11072/8). (CC @johannesmenzel.)

I thought I'll see if I can update it from v1.3.4 to v1.5.8. It was a little bit of effort but it's working now. To do this, I built both v1.3.4 and v1.5.18 on my Zynthian. Then I went through the diff between both dsp.ttl files and applied the changes to Zynthian's modified dsp.ttl in classic three-way-merge fashion. Then I spent way too long pondering how the new parameters should be organized into 4-knob input groups.

This is the result. I split the change up into two commits:

* The first one for simpler changes: Updated parameter value ranges, added new enum values for existing parameters, and added the new "Sidechain" audio input pair.
* The second one for adding new parameters and reorganizing input groups.

Noteworthy features that I'm aware of:

* Much improved behavior when hitting the polyphony limit.
  * Most importantly, if you keep holding a note, it now prioritizes that one over a newer note that is not held anymore.
  * New boolean parameters "Reuse Voices" and "Fadeout Repeated Notes". Not sure right now how they work exactly.
* New mallet parameters: mallet type (various samples, or a purely mathematical impulse), mallet filter, pitch factor and keytrack modifier for mallet pitch. The mallet is now very versatile.
* Tension parameters for noise attack, decay and release.
* New resonator model types: "Marimba2", "Bell", and "Djembe".
* Resonator "Material" and "Tone" parameters can now be velocity-modulated as well.
* More noise parameters can now be velocity-modulated. In particular, all four noise envelope parameters as well as the filter section's "Frequency" and "Q" parameters.
* The range of all velocity modulation parameters has been expanded: originally 0 to 1, now -1 to 1. Specifying a value below 0 means that if you hit the note harder, the parameter value will decrease rather than increase.

Challenges and questions:

* I gave my best shot at assigning (and reassigning) display groups, but please review my changes carefully because this is my first patch for Zynthian.
  * Notably, I removed the "Global Mix" group and folded Mallet/Noise mix parameter into their respective "Setup" groups. Plus a few other changes that made either logical or practical sense in my opinion.
  * The original UI can be a little cleaner because some of the parameters are only relevant for certain resonator models or coupling modes. Not sure if there is any infrastructure to selectively show parameters.
* The set of Velocity Modulation groups, in particular, poses a challenge for organization.
  * In the original UI, it's on a separate page that overlays (some of) the original knobs. Should the velocity-modulated parameters be listed close to their base parameters, or in a separate group just below the base parameter group, or all velocity modulation parameters grouped together at the very bottom?
  * After playing with the parameters a bit, I decided to pull velocity modulation parameters closer to their base parameters in most cases. I left them in separate groups for "Noise - Filter" (splitting the filter parameters feels awkward) and for "Noise - Envelope" (the envelope base parameters should stay together to keep the whole envelope graph on one page). The final set of groups feels right to me, but feel free to play with it if you don't like it.
* `plug:a_cut` and `plug:b_cut` parameters changed their min/max values to a completely different range: previously 20 to 20000, now -1 to 1.
  * Do we need to worry about migrations?
* `plug:mallet_type` (new parameter) has a bunch of `"Reserved"` values as well as `"User File"`. I left those enum values out from the custom dsp.ttl, because they're not really useful in the Zynthian interface anyway?
  * The `"User File"` enum option  (i.e. use custom filter sample) could be useful, not sure how it would be integrated though.
* `plug:a_partials` and `plug:b_partials` have new enumeration values labelled "1" and "2", listed only after the existing ones "4", "8", "16", "32" and "64". The internal `rdf:value` for the new "1" and "2" values is larger than the original ones and presumably can't be listed first if `rdf:value` determines the order?
  * The original UI appends "1" and "2" at the end of its options list too, so I guess it's okay to keep the weird order.
* I put the new "Mallet Keytrack" parameter (modifies mallet pitch) next to "Mallet Pitch" in the "Mallet - Setup" group, I think that makes the most sense in regular use. Although logically it could also go into the newly introduced "Keyboard" group.

Unrelated to the upgrade:
* The polyphony limit (and some other settings too, I think?) is not exposed through an LV2 parameter. It would be nice to have this configurable in Chain Control, but I guess that should be tackled by upstream RipplerX instead of worked around?

After the change, the list of parameters is now grouped like this:

* Resonator Setup: a on, b on, stereoizer
* Resonator Mix: coupling (a+b or a>b), a+b mix, a>b split, gain
* Resonator Pitch: A coarse pitch, A fine pitch, B coarse pitch, B fine pitch
* Resonator A - Model: model, partials, ratio, tube radius
* Resonator A - Material: material, velmod material, hit position, velmod hitpos
* Resonator A - Tone: tone, velmod tone, inharmonic, velmod inharmonic
* Resonator A - Attenuation: decay, velmod decay, release, cut
* (...Resonator B groups same as the 4 Resonator A groups above...)
* Mallet Setup: mallet mix, velmod mallet mix, pitch, mallet keytrack
* Mallet Material: mallet type, stiffness, velmod stiffness
* Mallet Tone: resonance, velmod resonance, filter
* Noise Setup: noise mix, velmod noise mix, noise DC (OSC intensity)
* Noise Filter: resonance, freq, q, filter mode
* Noise Filter - Velocity Modulation: velmod resonance, velmod freq, velmod q
* Noise Envelope: ADSR
* Noise Envelope - Velocity Modulation: velmod equivalents for ADSR
* Noise Envelope - Tension: tension parameters for attack, decay and release (but not sustain)
* Keyboard: pitchbend range, reuse voices, fadeout repeated notes

Here is a [Release build for ARM](https://github.com/user-attachments/files/23404753/ripplerx-1.5.18.tar.gz) that works on the Zynthian, at least for my RPi 5. Needless to say, this goes hand in hand with the amended dsp.ttl from this PR.